### PR TITLE
Widen compatibility for Linux builds.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -270,6 +270,11 @@ jobs:
           distribution: 'corretto'
           gpg-private-key: ${{ secrets.SONATYPE_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Set up QEMU for aarch64 on Linux
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
       - uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
       - name: Compile
@@ -299,6 +304,11 @@ jobs:
           rm -fv java-*/*-sources.jar
           rm -fv java-*/*-javadoc.jar
           for artifact in java-*; do unzip -o $artifact/*.jar -d combined-jar; done
+          # Quick test that the JARs were built for the correct architectures
+          file combined-jar/linux-x64/libvoyager.so | grep x86
+          file combined-jar/macos-x64/libvoyager.so | grep x86
+          file combined-jar/linux-aarch64/libvoyager.so | grep aarch64
+          file combined-jar/macos-aarch64/libvoyager.so | grep arm64
           zip -r $(ls java-* | grep jar | tail -n 1) combined-jar/*
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -305,10 +305,14 @@ jobs:
           rm -fv java-*/*-javadoc.jar
           for artifact in java-*; do unzip -o $artifact/*.jar -d combined-jar; done
           # Quick test that the JARs were built for the correct architectures
+          echo "Checking linux-x64/libvoyager.so for x86 architecture..."
           file combined-jar/linux-x64/libvoyager.so | grep x86
-          file combined-jar/macos-x64/libvoyager.so | grep x86
+          echo "Checking mac-x64/libvoyager.dylib for x86 architecture..."
+          file combined-jar/mac-x64/libvoyager.dylib | grep x86
+          echo "Checking linux-aarch64/libvoyager.so for aarch64 architecture..."
           file combined-jar/linux-aarch64/libvoyager.so | grep aarch64
-          file combined-jar/macos-aarch64/libvoyager.so | grep arm64
+          echo "Checking mac-aarch64/libvoyager.dylib for arm64 architecture..."
+          file combined-jar/mac-aarch64/libvoyager.dylib | grep arm64
           zip -r $(ls java-* | grep jar | tail -n 1) combined-jar/*
       - uses: actions/upload-artifact@v3
         with:

--- a/java/Makefile
+++ b/java/Makefile
@@ -53,14 +53,14 @@ target/classes/linux-x64/$(LINUX_SOBJ): classpath.txt $(HEADERS)
 	cp -r $(addsuffix /*,$(JAVA_INC)) linux-build/include
 	# Why use Dockcross if we're already building on x86?
 	# We need to use an older version of GLIBC and GLIBCXX to ensure wide compatibility on Linux.
-	docker run -v $(shell realpath ../):/work dockcross/linux-x64 bash -c 'cd /work/java && $(PREBUILD_COMMAND) && $$CXX $(CXXFLAGS) -I linux-build/include -o $@ $(SOURCE)'
+	docker run -v $(shell realpath ../):/work dockcross/linux-x64 bash -x -c 'cd /work/java && $(PREBUILD_COMMAND) && $$CXX $(CXXFLAGS) -I linux-build/include -o $@ $(SOURCE)'
 
 target/classes/linux-aarch64/$(LINUX_SOBJ): classpath.txt $(HEADERS)
 	mkdir -p target/classes/linux-aarch64/
 	mkdir -p linux-build
 	cp -r $(CPP_SRC_DIR) linux-build/include
 	cp -r $(addsuffix /*,$(JAVA_INC)) linux-build/include
-	docker run -v $(shell realpath ../):/work dockcross/linux-arm64 bash -c 'cd /work/java && $(PREBUILD_COMMAND) && $$CXX $(CXXFLAGS) -I linux-build/include -o $@ $(SOURCE)'
+	docker run -v $(shell realpath ../):/work dockcross/linux-arm64 bash -x -c 'cd /work/java && $(PREBUILD_COMMAND) && $$CXX $(CXXFLAGS) -I linux-build/include -o $@ $(SOURCE)'
 
 target/classes/mac-x64/$(MAC_SOBJ): classpath.txt $(HEADERS)
 	mkdir -p target/classes/mac-x64/

--- a/java/Makefile
+++ b/java/Makefile
@@ -14,10 +14,10 @@ HEADERS   := $(SOURCE:.cpp=.h)
 JAVA_SRC  := ./src/main/java
 
 ifeq ($(UNAME_S),Linux)
-CC        := clang++
 JAVA_INC  := $(JAVA_HOME)/include $(JAVA_HOME)/include/linux
 ALL_OBJS  := target/classes/linux-x64/$(LINUX_SOBJ) target/classes/linux-aarch64/$(LINUX_SOBJ)
 CXXFLAGS  := -I. -lc -shared -std=c++17 -I ./include $(addprefix -I,$(JAVA_INC)) -I $(CPP_SRC_DIR) -fPIC -O3
+PREBUILD_COMMAND := sudo apt-get update && sudo apt-get install -y ca-certificates-java openjdk-11-jre-headless; { curl https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz | sudo tar -xvzf - -C /opt ; }; export M2_HOME=/opt/apache-maven-3.9.2 && export PATH=\"${M2_HOME}/bin:${PATH}\"
 else ifeq ($(UNAME_S),Darwin)
 CC        := clang++
 JAVA_INC  := $(JAVA_HOME)/include $(JAVA_HOME)/include/darwin
@@ -51,14 +51,16 @@ target/classes/linux-x64/$(LINUX_SOBJ): classpath.txt $(HEADERS)
 	mkdir -p linux-build
 	cp -r $(CPP_SRC_DIR) linux-build/include
 	cp -r $(addsuffix /*,$(JAVA_INC)) linux-build/include
-	$(CC) $(CXXFLAGS) -I linux-build/include -o $@ $(SOURCE)
+	# Why use Dockcross if we're already building on x86?
+	# We need to use an older version of GLIBC and GLIBCXX to ensure wide compatibility on Linux.
+	docker run -v $(shell realpath ../):/work dockcross/linux-x64 bash -c 'cd /work/java && $(PREBUILD_COMMAND) && $$CXX $(CXXFLAGS) -I linux-build/include -o $@ $(SOURCE)'
 
 target/classes/linux-aarch64/$(LINUX_SOBJ): classpath.txt $(HEADERS)
 	mkdir -p target/classes/linux-aarch64/
 	mkdir -p linux-build
 	cp -r $(CPP_SRC_DIR) linux-build/include
 	cp -r $(addsuffix /*,$(JAVA_INC)) linux-build/include
-	$(CC) $(CXXFLAGS) -I linux-build/include -o $@ $(SOURCE)
+	docker run -v $(shell realpath ../):/work dockcross/linux-arm64 bash -c 'cd /work/java && $(PREBUILD_COMMAND) && $$CXX $(CXXFLAGS) -I linux-build/include -o $@ $(SOURCE)'
 
 target/classes/mac-x64/$(MAC_SOBJ): classpath.txt $(HEADERS)
 	mkdir -p target/classes/mac-x64/

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -12,7 +12,7 @@
 
   <name>voyager</name>
   <artifactId>voyager</artifactId>
-  <version>1.2.2</version>
+  <version>1.2.4</version>
 
   <scm>
     <url>https://github.com/spotify/voyager</url>


### PR DESCRIPTION
Two fixes:
 - Use `dockcross` to properly build our Java Linux binaries on `x86_64` _and_ `aarch64`
 - Ensure we use a sufficiently old version of `GLIBC` (2.29, 2019-02-01) and/or `GLIBCXX` (3.4.22, 2016-04-27) to give compatibility with older Linux distributions