### PR TITLE
Add validation for GLIBC and GLIBCXX versions.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -313,6 +313,17 @@ jobs:
           file combined-jar/linux-aarch64/libvoyager.so | grep aarch64
           echo "Checking mac-aarch64/libvoyager.dylib for arm64 architecture..."
           file combined-jar/mac-aarch64/libvoyager.dylib | grep arm64
+
+          # Check the Linux JARs to ensure a sufficiently old required GLIBC and GLIBCXX version:
+          echo "Checking linux-aarch64/libvoyager.so for GLIBC 2.27..."
+          objdump -T combined-jar/linux-aarch64/libvoyager.so | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 2\.27
+          echo "Checking linux-aarch64/libvoyager.so for GLIBCXX 3.4.22..."
+          objdump -T combined-jar/linux-aarch64/libvoyager.so | grep GLIBCXX | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 3\.4\.22
+          echo "Checking linux-x64/libvoyager.so for GLIBC 2.27..."
+          objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 2\.27
+          echo "Checking linux-x64/libvoyager.so for GLIBCXX 3.4.22..."
+          objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBCXX | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 3\.4\.22
+
           zip -r $(ls java-* | grep jar | tail -n 1) combined-jar/*
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -319,8 +319,8 @@ jobs:
           objdump -T combined-jar/linux-aarch64/libvoyager.so | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 2\.27
           echo "Checking linux-aarch64/libvoyager.so for GLIBCXX 3.4.22..."
           objdump -T combined-jar/linux-aarch64/libvoyager.so | grep GLIBCXX | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 3\.4\.22
-          echo "Checking linux-x64/libvoyager.so for GLIBC 2.27..."
-          objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 2\.27
+          echo "Checking linux-x64/libvoyager.so for GLIBC 2.29..."
+          objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 2\.29
           echo "Checking linux-x64/libvoyager.so for GLIBCXX 3.4.22..."
           objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBCXX | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 3\.4\.22
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add the following artifact to your `pom.xml`:
 <dependency>
   <groupId>com.spotify</groupId>
   <artifactId>voyager</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.5</version>
 </dependency>
 ```
 You can find the latest version on [Voyager's Releases page](https://github.com/spotify/voyager/releases).
@@ -44,7 +44,7 @@ You can find the latest version on [Voyager's Releases page](https://github.com/
 
 Add the following artifact to your `build.sbt`:
 ```sbt
-"com.spotify" % "voyager" % "1.2.1"
+"com.spotify" % "voyager" % "1.2.5"
 ```
 You can find the latest version on [Voyager's Releases page](https://github.com/spotify/voyager/releases).
 

--- a/java/Makefile
+++ b/java/Makefile
@@ -60,7 +60,7 @@ target/classes/linux-aarch64/$(LINUX_SOBJ): classpath.txt $(HEADERS)
 	mkdir -p linux-build
 	cp -r $(CPP_SRC_DIR) linux-build/include
 	cp -r $(addsuffix /*,$(JAVA_INC)) linux-build/include
-	docker run -v $(shell realpath ../):/work dockcross/linux-arm64 bash -x -c 'cd /work/java && $(PREBUILD_COMMAND) && $$CXX $(CXXFLAGS) -I linux-build/include -o $@ $(SOURCE)'
+	docker run -v $(shell realpath ../):/work dockcross/linux-arm64-lts bash -x -c 'cd /work/java && $(PREBUILD_COMMAND) && $$CXX $(CXXFLAGS) -I linux-build/include -o $@ $(SOURCE)'
 
 target/classes/mac-x64/$(MAC_SOBJ): classpath.txt $(HEADERS)
 	mkdir -p target/classes/mac-x64/

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -12,7 +12,7 @@
 
   <name>voyager</name>
   <artifactId>voyager</artifactId>
-  <version>1.2.4</version>
+  <version>1.2.5</version>
 
   <scm>
     <url>https://github.com/spotify/voyager</url>


### PR DESCRIPTION
Using the `linux-arm64-lts` Dockcross image should lower our required GLIBC and GLIBCXX versions, widening Linux compatibility even more.