### PR TITLE
Update contribution docs and enable stubgen virtualenv compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,14 @@ To compile Voyager from scratch, the following packages will need to be installe
 ```shell
 git clone git@github.com:spotify/voyager.git
 cd voyager
-pip3 install pybind11 tox
+pip3 install -r python/dev-requirements.txt
 pip3 install .
 ```
 
 To compile a debug build of `voyager` that allows using a debugger (like gdb or lldb), use the following command to build the package locally and install a symbolic link for debugging:
 ```shell
-DEBUG=1 python3 setup.py build develop
+cd python
+DEBUG=1 python3 python/setup.py build develop
 ```
 
 Then, you can `import voyager` from Python (or run the tests with `tox`) to test out your local changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ pip3 install .
 To compile a debug build of `voyager` that allows using a debugger (like gdb or lldb), use the following command to build the package locally and install a symbolic link for debugging:
 ```shell
 cd python
-DEBUG=1 python3 python/setup.py build develop
+DEBUG=1 python3 setup.py build develop
 ```
 
 Then, you can `import voyager` from Python (or run the tests with `tox`) to test out your local changes.

--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -1,4 +1,8 @@
 -r test-requirements.txt
 numpy
 pybind11
+pybind11-stubgen
 ruff
+psutil
+mypy
+sphinx

--- a/python/scripts/generate_type_stubs_and_docs.py
+++ b/python/scripts/generate_type_stubs_and_docs.py
@@ -319,8 +319,9 @@ def main():
                 )
         # Re-run this same script in a fresh interpreter, but with skip_regenerating_type_hints
         # enabled:
+        interpreter = shutil.which("python3") or psutil.Process(os.getpid()).exe()
         subprocess.check_call(
-            [psutil.Process(os.getpid()).exe()] + sys.argv + ["--skip-regenerating-type-hints"]
+            [interpreter] + sys.argv + ["--skip-regenerating-type-hints"]
         )
         return
 


### PR DESCRIPTION
Getting my local env set up with the repo and found some stuff that was out of date.
Also `psutil.Process(os.getpid()).exe()` will call out to your global python interpreter if you're in a virtualenv.  If your global env doesn't have all of the requirements install it will fail with ModuleNotFoundError, so let's first check what `python3` resolves to and use that in order to execute the subprocess within the virtualenv.