### PR TITLE
call C++ destructor instead of free

### DIFF
--- a/java/com_spotify_voyager_jni_Index.cpp
+++ b/java/com_spotify_voyager_jni_Index.cpp
@@ -766,7 +766,8 @@ void Java_com_spotify_voyager_jni_Index_nativeDestructor(JNIEnv *env,
                                                          jobject self) {
   try {
     if (Index *index = getHandle<Index>(env, self, true)) {
-      free(index);
+      delete index;
+      setHandle<Index>(env, self, nullptr);
     }
   } catch (std::exception const &e) {
     if (!env->ExceptionCheck()) {

--- a/java/src/main/java/com/spotify/voyager/jni/Index.java
+++ b/java/src/main/java/com/spotify/voyager/jni/Index.java
@@ -277,6 +277,15 @@ public class Index implements Closeable {
     nativeDestructor();
   }
 
+  @Override
+  protected void finalize() throws Throwable {
+    try {
+      nativeDestructor();
+    } finally {
+      super.finalize();
+    }
+  }
+
   private native void nativeConstructor(
       SpaceType space,
       int numDimensions,


### PR DESCRIPTION
`free` will just free the memory for the pointer itself, by calling the native destructor it should actually free the underlying memory.