### PR TITLE
Implement order preserving transform for inner product

### DIFF
--- a/cpp/array_utils.h
+++ b/cpp/array_utils.h
@@ -49,12 +49,18 @@ public:
   NDArray(std::vector<T> data, std::array<int, Dims> shape)
       : data(data), shape(shape), strides(computeStrides()) {}
 
+  NDArray(T *inputPointer, std::array<int, Dims> shape)
+      : data(computeNumElements(shape)), shape(shape),
+        strides(computeStrides()) {
+    std::memcpy(data.data(), inputPointer, data.size() * sizeof(T));
+  }
+
   T *operator[](int indexInZerothDimension) const {
     return const_cast<T *>(data.data() + (indexInZerothDimension * strides[0]));
   }
 
 private:
-  std::array<int, Dims> computeStrides() {
+  std::array<int, Dims> computeStrides() const {
     std::array<int, Dims> _strides;
     _strides[Dims - 1] = 1;
 
@@ -62,6 +68,14 @@ private:
       _strides[i] = _strides[i + 1] * shape[i + 1];
     }
     return _strides;
+  }
+
+  size_t computeNumElements(std::array<int, Dims> shape) const {
+    size_t numOutputElements = 1;
+    for (int i = 0; i < shape.size(); i++) {
+      numOutputElements *= shape[i];
+    }
+    return numOutputElements;
   }
 };
 

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -70,6 +70,17 @@ py::array_t<T> ndArrayToPyArray(NDArray<T, Dims> input) {
   py::array_t<T> output(input.shape);
   T *outputPtr = static_cast<T *>(const_cast<T *>(output.data()));
 
+  size_t numOutputElements = 1;
+  for (int i = 0; i < input.shape.size(); i++) {
+    numOutputElements *= input.shape[i];
+  }
+  if (input.data.size() != numOutputElements) {
+    throw std::runtime_error("Internal error: NDArray input size (" +
+                             std::to_string(input.data.size()) +
+                             " elements) does not match output shape: (" +
+                             std::to_string(numOutputElements) + " elements).");
+  }
+
   {
     py::gil_scoped_release release;
     std::copy(input.data.begin(), input.data.end(), outputPtr);

--- a/python/tests/test_index_creation.py
+++ b/python/tests/test_index_creation.py
@@ -361,3 +361,28 @@ def test_add_single_item(
         np.testing.assert_allclose(index.get_vector(label), expected_vector, atol=tolerance)
 
     np.testing.assert_allclose(index.get_vectors(labels), input_data, atol=tolerance)
+
+
+def test_accuracy_for_inner_product():
+    space = voyager.Space.InnerProduct
+    num_dimensions = 1024
+
+    np.random.seed(1)
+    input_data = np.random.rand(10000, num_dimensions)
+    index = voyager.Index(space=space, num_dimensions=num_dimensions)
+
+    # Sort the data descending by norm:
+    norms = np.sqrt(np.sum(np.power(input_data, 2), axis=1))
+    input_data = input_data[np.argsort(norms)[::-1]]
+    norms = np.sqrt(np.sum(np.power(input_data, 2), axis=1))
+    assert list(norms) == list(reversed(sorted(norms)))
+
+    # Don't insert in batch; this guarantees deterministic ordering.
+    for vector in input_data:
+        index.add_item(vector)
+
+    query = np.random.rand(num_dimensions)
+    expected_distances = np.dot(input_data, np.expand_dims(query, -1))
+    neighbors, distances = index.query(query, k=3, query_ef=3)
+    assert neighbors[0] == np.argmax(expected_distances)
+    assert abs(distances[0] - (1.0 - np.amax(expected_distances))) < 0.01


### PR DESCRIPTION
As described in [this paper](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/XboxInnerProduct.pdf) this is a mechanism to reduce the maximum inner-product search problem into a nearest-neighbors search problem by adding an extra dimension to each vector which preserves the triangle inequality. 

Per the paper:
> The triangle inequality does not hold between vectors x,
yi, and yj when an inner product compares them, as is the
case in MIP. Many efficient search data structures rely on
the triangle inequality, and if MIP can be transformed to
NN with its Euclidian distance, these data structures would
immediately become applicable. Our first theorem states
that MIP can be reduced to NN by having an Euclidian
metric in one more dimension than the original problem.

This extra dimension is equal to `sqrt(max_norm**2 - norm(x)**2)` for each vector `x` in the dataset, where `max_norm` is the maximum norm of all vectors in the dataset. 

One thing to note on the implementation in this library, since Voyager is not exclusively meant to be used in batch and allows adding new items after the index was initially built, there is no way of knowing what the maximum norm for the dataset will be since the dataset is unknown at build time. As such, we simply calculate the extra dimension based on the data that we have seen so far. This means that if you add a new vector with a larger norm than anything seen so far, the accuracy of the index will suffer. This is similar to the approach taken by Vespa, see their blog post on the matter [here](https://blog.vespa.ai/announcing-maximum-inner-product-search/). If you have a priori knowledge of your dataset it is recommended that you insert the item with the largest norm first.

Still TODO: document this feature in the python and java docs