### PR TITLE
Remove need for GPG key at test time.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -67,9 +67,7 @@ jobs:
       - name: Compile
         run: make
       - name: Run Tests
-        run: mvn --batch-mode verify
-        env:
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.SONATYPE_PASSPHRASE }}
+        run: mvn --batch-mode test
 
   run-python-tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Should resolve the issue seen in #35.

The issue is that GitHub Actions secrets aren't used for PRs from forks:
> Anyone with collaborator access to this repository can use these secrets and variables for actions. They are not passed to workflows that are triggered by a pull request from a fork.

Our build setup passes `MAVEN_GPG_PASSPHRASE` into the build at test time, even though it's not needed; and when receiving a PR from an external collaborator, the variable is empty:
```
 mvn --batch-mode verify
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Corretto_jdk/11.0.21-9.1/x64
    JAVA_HOME_11_X64: /opt/hostedtoolcache/Java_Corretto_jdk/11.0.21-9.1/x64
    MAVEN_GPG_PASSPHRASE: 
```

We don't need to GPG-sign the package just to test it, given that the default Maven lifecycle is 
`validate`, `compile`, `test`, `package`, `verify`, `install`, `deploy` (in that order). This PR attempts to fix the issue by switching from `mvn verify` to `mvn test`.