### PR TITLE
Added  getNumElements + getVector

### DIFF
--- a/java/src/main/java/com/spotify/voyager/jni/StringIndex.java
+++ b/java/src/main/java/com/spotify/voyager/jni/StringIndex.java
@@ -253,15 +253,9 @@ public class StringIndex implements Closeable {
   }
 
   public void addItem(String name, float[] vector) {
-    int nextIndex = names.indexOf(name);
-    if (nextIndex == -1) {
-      // we add it
-      index.addItem(vector, names.size());
-      names.add(name);
-    } else {
-      // up just update vector
-      index.addItem(vector, nextIndex);
-    }
+    int nextIndex = names.size();
+    index.addItem(vector, nextIndex);
+    names.add(name);
   }
 
   public void addItem(String name, List<Float> vector) {
@@ -278,14 +272,9 @@ public class StringIndex implements Closeable {
     Iterator<Entry<String, List<Float>>> iterator = vectors.entrySet().iterator();
     for (int i = 0; i < numVectors; i++) {
       Entry<String, List<Float>> nextVector = iterator.next();
-      // Check if we already have this vector - and update it if needed
-      int nextIndex = names.indexOf(nextVector.getKey());
-      if (nextIndex == -1) {
-        newNames.add(nextVector.getKey());
-        nextIndex = names.size() + i;
-      }
+      newNames.add(nextVector.getKey());
       assignPrimitive(nextVector.getValue(), primitiveVectors[i]);
-      labels[i] = nextIndex;
+      labels[i] = names.size() + i;
     }
 
     names.addAll(newNames);

--- a/java/src/main/java/com/spotify/voyager/jni/StringIndex.java
+++ b/java/src/main/java/com/spotify/voyager/jni/StringIndex.java
@@ -254,12 +254,12 @@ public class StringIndex implements Closeable {
 
   public void addItem(String name, float[] vector) {
     int nextIndex = names.indexOf(name);
-    if (nextIndex==-1) {
-      //we add it
+    if (nextIndex == -1) {
+      // we add it
       index.addItem(vector, names.size());
       names.add(name);
     } else {
-      //up just update vector
+      // up just update vector
       index.addItem(vector, nextIndex);
     }
   }
@@ -278,9 +278,9 @@ public class StringIndex implements Closeable {
     Iterator<Entry<String, List<Float>>> iterator = vectors.entrySet().iterator();
     for (int i = 0; i < numVectors; i++) {
       Entry<String, List<Float>> nextVector = iterator.next();
-      //Check if we already have this vector - and update it if needed
+      // Check if we already have this vector - and update it if needed
       int nextIndex = names.indexOf(nextVector.getKey());
-      if (nextIndex==-1) {
+      if (nextIndex == -1) {
         newNames.add(nextVector.getKey());
         nextIndex = names.size() + i;
       }

--- a/java/src/main/java/com/spotify/voyager/jni/StringIndex.java
+++ b/java/src/main/java/com/spotify/voyager/jni/StringIndex.java
@@ -253,9 +253,15 @@ public class StringIndex implements Closeable {
   }
 
   public void addItem(String name, float[] vector) {
-    int nextIndex = names.size();
-    index.addItem(vector, nextIndex);
-    names.add(name);
+    int nextIndex = names.indexOf(name);
+    if (nextIndex==-1) {
+      //we add it
+      index.addItem(vector, names.size());
+      names.add(name);
+    } else {
+      //up just update vector
+      index.addItem(vector, nextIndex);
+    }
   }
 
   public void addItem(String name, List<Float> vector) {
@@ -272,13 +278,26 @@ public class StringIndex implements Closeable {
     Iterator<Entry<String, List<Float>>> iterator = vectors.entrySet().iterator();
     for (int i = 0; i < numVectors; i++) {
       Entry<String, List<Float>> nextVector = iterator.next();
-      newNames.add(nextVector.getKey());
+      //Check if we already have this vector - and update it if needed
+      int nextIndex = names.indexOf(nextVector.getKey());
+      if (nextIndex==-1) {
+        newNames.add(nextVector.getKey());
+        nextIndex = names.size() + i;
+      }
       assignPrimitive(nextVector.getValue(), primitiveVectors[i]);
-      labels[i] = names.size() + i;
+      labels[i] = nextIndex;
     }
 
     names.addAll(newNames);
     index.addItems(primitiveVectors, labels, -1);
+  }
+
+  public long getNumElements() {
+    return index.getNumElements();
+  }
+
+  public float[] getVector(String name) {
+    return index.getVector(names.indexOf(name));
   }
 
   private float[] toPrimitive(List<Float> vector) {

--- a/java/src/test/java/com/spotify/voyager/jni/StringIndexTest.java
+++ b/java/src/test/java/com/spotify/voyager/jni/StringIndexTest.java
@@ -265,45 +265,46 @@ public class StringIndexTest {
   public void itUpsertItem() throws Exception {
     List<Vector> testVectors = TestUtils.getTestVectors();
     try (final StringIndex index =
-                 new StringIndex(
-                         SpaceType.Cosine,
-                         testVectors.get(0).vector.length,
-                         20,
-                         2,
-                         0,
-                         2,
-                         StorageDataType.E4M3)) {
+        new StringIndex(
+            SpaceType.Cosine,
+            testVectors.get(0).vector.length,
+            20,
+            2,
+            0,
+            2,
+            StorageDataType.E4M3)) {
       Vector v1 = testVectors.get(0);
       Vector v2 = testVectors.get(1);
-      //Add couple of vectors//
-      index.addItem(v1.name,v1.vector);
-      index.addItem(v2.name,v2.vector);
-      //Again add the first one which should be an update not an insert with the same name
-      index.addItem(v1.name,v1.vector);
-      //We should only have 2 entries in it. 
+      // Add couple of vectors//
+      index.addItem(v1.name, v1.vector);
+      index.addItem(v2.name, v2.vector);
+      // Again add the first one which should be an update not an insert with the same name
+      index.addItem(v1.name, v1.vector);
+      // We should only have 2 entries in it.
       assertEquals(2, index.getNumElements());
     }
   }
 
   @Test
   public void itUpsertItems() throws Exception {
-    int testSize=15;
+    int testSize = 15;
     List<Vector> testVectors = TestUtils.getTestVectors();
     try (final StringIndex index =
-                 new StringIndex(
-                         SpaceType.Cosine,
-                         testVectors.get(0).vector.length,
-                         20,
-                         testSize,
-                         0,
-                         testSize,
-                         StorageDataType.E4M3)) {
+        new StringIndex(
+            SpaceType.Cosine,
+            testVectors.get(0).vector.length,
+            20,
+            testSize,
+            0,
+            testSize,
+            StorageDataType.E4M3)) {
       Map<String, List<Float>> vectors =
-              testVectors.stream().limit(testSize)
-                      .collect(Collectors.toMap(vec -> vec.name, vec -> convert(vec.vector)));
+          testVectors.stream()
+              .limit(testSize)
+              .collect(Collectors.toMap(vec -> vec.name, vec -> convert(vec.vector)));
       index.addItems(vectors);
       assertEquals(vectors.size(), index.getNumElements());
-      //If we add it again number of elements  should stay the same//
+      // If we add it again number of elements  should stay the same//
       index.addItems(vectors);
       assertEquals(vectors.size(), index.getNumElements());
     }

--- a/java/src/test/java/com/spotify/voyager/jni/StringIndexTest.java
+++ b/java/src/test/java/com/spotify/voyager/jni/StringIndexTest.java
@@ -275,7 +275,7 @@ public class StringIndexTest {
             StorageDataType.E4M3)) {
       Vector v1 = testVectors.get(0);
       Vector v2 = testVectors.get(1);
-      // Add couple of vectors//
+      // Add a couple of vectors//
       index.addItem(v1.name, v1.vector);
       index.addItem(v2.name, v2.vector);
       // Again add the first one which should be an update not an insert with the same name
@@ -304,7 +304,7 @@ public class StringIndexTest {
               .collect(Collectors.toMap(vec -> vec.name, vec -> convert(vec.vector)));
       index.addItems(vectors);
       assertEquals(vectors.size(), index.getNumElements());
-      // If we add it again number of elements  should stay the same//
+      // If we add then again number of elements  should stay the same//
       index.addItems(vectors);
       assertEquals(vectors.size(), index.getNumElements());
     }

--- a/java/src/test/java/com/spotify/voyager/jni/StringIndexTest.java
+++ b/java/src/test/java/com/spotify/voyager/jni/StringIndexTest.java
@@ -261,6 +261,54 @@ public class StringIndexTest {
     }
   }
 
+  @Test
+  public void itUpsertItem() throws Exception {
+    List<Vector> testVectors = TestUtils.getTestVectors();
+    try (final StringIndex index =
+                 new StringIndex(
+                         SpaceType.Cosine,
+                         testVectors.get(0).vector.length,
+                         20,
+                         2,
+                         0,
+                         2,
+                         StorageDataType.E4M3)) {
+      Vector v1 = testVectors.get(0);
+      Vector v2 = testVectors.get(1);
+      //Add couple of vectors//
+      index.addItem(v1.name,v1.vector);
+      index.addItem(v2.name,v2.vector);
+      //Again add the first one which should be an update not an insert with the same name
+      index.addItem(v1.name,v1.vector);
+      //We should only have 2 entries in it. 
+      assertEquals(2, index.getNumElements());
+    }
+  }
+
+  @Test
+  public void itUpsertItems() throws Exception {
+    int testSize=15;
+    List<Vector> testVectors = TestUtils.getTestVectors();
+    try (final StringIndex index =
+                 new StringIndex(
+                         SpaceType.Cosine,
+                         testVectors.get(0).vector.length,
+                         20,
+                         testSize,
+                         0,
+                         testSize,
+                         StorageDataType.E4M3)) {
+      Map<String, List<Float>> vectors =
+              testVectors.stream().limit(testSize)
+                      .collect(Collectors.toMap(vec -> vec.name, vec -> convert(vec.vector)));
+      index.addItems(vectors);
+      assertEquals(vectors.size(), index.getNumElements());
+      //If we add it again number of elements  should stay the same//
+      index.addItems(vectors);
+      assertEquals(vectors.size(), index.getNumElements());
+    }
+  }
+
   public static class CustomResult {
     private final String name;
     private final float distance;

--- a/java/src/test/java/com/spotify/voyager/jni/StringIndexTest.java
+++ b/java/src/test/java/com/spotify/voyager/jni/StringIndexTest.java
@@ -261,55 +261,6 @@ public class StringIndexTest {
     }
   }
 
-  @Test
-  public void itUpsertItem() throws Exception {
-    List<Vector> testVectors = TestUtils.getTestVectors();
-    try (final StringIndex index =
-        new StringIndex(
-            SpaceType.Cosine,
-            testVectors.get(0).vector.length,
-            20,
-            2,
-            0,
-            2,
-            StorageDataType.E4M3)) {
-      Vector v1 = testVectors.get(0);
-      Vector v2 = testVectors.get(1);
-      // Add a couple of vectors//
-      index.addItem(v1.name, v1.vector);
-      index.addItem(v2.name, v2.vector);
-      // Again add the first one which should be an update not an insert with the same name
-      index.addItem(v1.name, v1.vector);
-      // We should only have 2 entries in it.
-      assertEquals(2, index.getNumElements());
-    }
-  }
-
-  @Test
-  public void itUpsertItems() throws Exception {
-    int testSize = 15;
-    List<Vector> testVectors = TestUtils.getTestVectors();
-    try (final StringIndex index =
-        new StringIndex(
-            SpaceType.Cosine,
-            testVectors.get(0).vector.length,
-            20,
-            testSize,
-            0,
-            testSize,
-            StorageDataType.E4M3)) {
-      Map<String, List<Float>> vectors =
-          testVectors.stream()
-              .limit(testSize)
-              .collect(Collectors.toMap(vec -> vec.name, vec -> convert(vec.vector)));
-      index.addItems(vectors);
-      assertEquals(vectors.size(), index.getNumElements());
-      // If we add then again number of elements  should stay the same//
-      index.addItems(vectors);
-      assertEquals(vectors.size(), index.getNumElements());
-    }
-  }
-
   public static class CustomResult {
     private final String name;
     private final float distance;


### PR DESCRIPTION
As reported in issues  https://github.com/spotify/voyager/issues/3 inserting string vector with the same name doesn't update it but it adds another one. 

I've modified inserting so that it checks for the key before adding it to the index. 

If this change is not wanted I could maybe create upsertItem upsertItems which would perform this way. 


