### PR TITLE
Fix for concurrency bug 

### DIFF
--- a/cpp/TypedIndex.h
+++ b/cpp/TypedIndex.h
@@ -360,7 +360,7 @@ public:
 
     int start = 0;
     if (!ep_added) {
-      size_t id = ids.size() ? ids.at(0) : (currentLabel);
+      size_t id = ids.size() ? ids.at(0) : (currentLabel.load());
       // TODO(psobot): Should inputVector be on the stack instead?
       std::vector<float> inputVector(actualDimensions);
       std::vector<data_t> convertedVector(actualDimensions);

--- a/cpp/TypedIndex.h
+++ b/cpp/TypedIndex.h
@@ -360,7 +360,7 @@ public:
 
     int start = 0;
     if (!ep_added) {
-      size_t id = ids.size() ? ids.at(0) : (currentLabel.fetch_add(1));
+      size_t id = ids.size() ? ids.at(0) : (currentLabel);
       // TODO(psobot): Should inputVector be on the stack instead?
       std::vector<float> inputVector(actualDimensions);
       std::vector<data_t> convertedVector(actualDimensions);

--- a/cpp/TypedIndex.h
+++ b/cpp/TypedIndex.h
@@ -360,7 +360,7 @@ public:
 
     int start = 0;
     if (!ep_added) {
-      size_t id = ids.size() ? ids.at(0) : (currentLabel.load());
+      size_t id = ids.size() ? ids.at(0) : (currentLabel.fetch_add(1));
       // TODO(psobot): Should inputVector be on the stack instead?
       std::vector<float> inputVector(actualDimensions);
       std::vector<data_t> convertedVector(actualDimensions);


### PR DESCRIPTION
## Description
When adding a point to an index without providing an id, we rely on `TypedIndex::currentLabel` to get one. But we are not doing it in a threadsafe way. This PR fixes that, solves #65 

## Changes Made

### C++
<!-- Describe changes made to the C++ code, including any new features, improvements, or bug fixes. -->
`TypedIndex::currentLabel` is now `std::atomic` and it's post-incremented atomically to get a new id when needed

## Testing
<!-- Outline the testing strategy employed to validate these changes. Include any relevant test cases or scenarios. -->

## Checklist
<!-- 
    Replace [ ] with [x] to check off items. 
    For items that are not applicable, simply remove the checkbox.
-->

- [x] My code follows the code style of this project.
- [x] I have added and/or updated appropriate documentation (if applicable).
- [x] All new and existing tests pass locally with these changes.
- [x] I have run static code analysis (if available) and resolved any issues.
- [x] I have considered backward compatibility (if applicable).
- [x] I have confirmed that this PR does not introduce any security vulnerabilities.

## Additional Comments
<!-- Add any additional comments or notes that might be helpful for reviewers or contributors. -->
