### PR TITLE
use user token for sonatype auth

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -402,7 +402,7 @@ jobs:
           distribution: 'corretto'
           server-id: ossrh
           server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+          server-password: MAVEN_USER_TOKEN
           gpg-private-key: ${{ secrets.SONATYPE_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Deploy
@@ -419,3 +419,4 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.SONATYPE_PASSPHRASE }}
+          MAVEN_USER_TOKEN: ${{ secrets.SONATYPE_USER_TOKEN }}


### PR DESCRIPTION
Per communication from the Maven Central team, they changed how auth works for publishing to Maven:
> To configure a publisher’s plugin authentication you would need to update your plugin settings to use a user token instead of the Nexus UI username and password login.

I generated a user token from my oss.sonatype.org account and set the SONATYPE_USERNAME secret to the generated username and the SONATYPE_USER_TOKEN secret to the generated token. The [linked doc](https://central.sonatype.org/publish/generate-token/) says to set the maven settings.xml username and password to use those values. I'm not 100% sure how the GH action here translates to that settings configuration, it's possible I'll need to remove the GPG private key and passphrase configs, I'll see if this works first. 

This PR sets the GH publish action to use the new username and user token secrets

![image](https://github.com/user-attachments/assets/1589a0e0-96a0-4be8-8941-dc2b9fee977c)
