### PR TITLE
Add benchmarking suite

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -188,6 +188,36 @@ jobs:
           LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so) \
           tox
 
+  run-benchmarks:
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    if: github.event_name == 'pull_request' 
+    name: Run benchmarks on ${{ matrix.os }}
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 
+          submodules: recursive
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y pkg-config 
+      - name: Install dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+          pip install -r dev-requirements.txt
+      - name: Run profiling
+        run: |
+             asv machine --yes
+             asv continuous --sort name --no-only-changed refs/remotes/origin/master ${{ github.sha }} | tee | sed  '1,/All benchmarks:/d' > $GITHUB_STEP_SUMMARY
+
   build-python-wheels:
     needs: [run-python-tests, run-python-tests-with-address-sanitizer]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -212,7 +212,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install wheel
-          pip install -r dev-requirements.txt
+          pip install -r python/dev-requirements.txt
       - name: Run profiling
         run: |
              asv machine --yes

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -213,7 +213,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install wheel
           pip install -r python/dev-requirements.txt
-      - name: Run profiling
+      - name: Run benchmarks
         run: |
              asv machine --yes
              asv continuous --sort name --no-only-changed refs/remotes/origin/main ${{ github.sha }} | tee >(sed '1,/All benchmarks:/d' > $GITHUB_STEP_SUMMARY)

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Run profiling
         run: |
              asv machine --yes
-             asv continuous --sort name --no-only-changed refs/remotes/origin/master ${{ github.sha }} | tee >(sed '1,/All benchmarks:/d' > $GITHUB_STEP_SUMMARY)
+             asv continuous --sort name --no-only-changed refs/remotes/origin/main ${{ github.sha }} | tee >(sed '1,/All benchmarks:/d' > $GITHUB_STEP_SUMMARY)
 
   build-python-wheels:
     needs: [run-python-tests, run-python-tests-with-address-sanitizer]

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Run profiling
         run: |
              asv machine --yes
-             asv continuous --sort name --no-only-changed refs/remotes/origin/master ${{ github.sha }} | tee | sed  '1,/All benchmarks:/d' > $GITHUB_STEP_SUMMARY
+             asv continuous --sort name --no-only-changed refs/remotes/origin/master ${{ github.sha }} | tee >(sed '1,/All benchmarks:/d' > $GITHUB_STEP_SUMMARY)
 
   build-python-wheels:
     needs: [run-python-tests, run-python-tests-with-address-sanitizer]

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ java/com_*.h
 java/classpath.txt
 java/linux-build/include/*
 python/voyager-headers
+.asv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,26 @@ pip3 install tox
 tox
 ```
 
+## Benchmarking
+
+We use `airspeed-velocity` for benchmarking - running all benchmarks to compare latest 
+commit againt previous should be as simple as:
+
+```
+pip3 install asv
+asv continuous --sort name --no-only-changed HEAD HEAD~1
+```
+
+To compare current commit against `main` branch:
+
+```
+pip3 install asv
+asv continuous --sort name --no-only-changed HEAD main
+```
+
+Please note that `airspeed-velocity` can only run benchmarks against a git commit, so if 
+you have uncommited code that you want to run benchmarks for, you need to commit it first.
+
 ## Style
 
 Use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) for C++ code, and `black` with defaults for Python code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ tox
 ## Benchmarking
 
 We use `airspeed-velocity` for benchmarking - running all benchmarks to compare latest 
-commit againt previous should be as simple as:
+commit against previous should be as simple as:
 
 ```
 pip3 install asv
@@ -108,7 +108,7 @@ asv continuous --sort name --no-only-changed HEAD main
 ```
 
 Please note that `airspeed-velocity` can only run benchmarks against a git commit, so if 
-you have uncommited code that you want to run benchmarks for, you need to commit it first.
+you have uncommited code that you want to run benchmarks for you need to commit it first.
 
 ## Style
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -5,8 +5,8 @@
     "repo": ".",
     "build_command": [
           "python -m pip install build",
-          "/usr/bin/cp -r {build_dir}/cpp {build_dir}/python/cpp",
-          "in-dir={build_dir}/python python -m build",
+          "pip install -r {build_dir}/python/dev-requirements.txt",
+          "in-dir={build_dir}/python python -m build --no-isolation",
           "/usr/bin/cp -r {build_dir}/python/dist/. {build_cache_dir}"
      ],
     "benchmark_dir": "benchmarks",

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -13,9 +13,8 @@
           "/usr/bin/cp -r {build_dir}/python/dist/. {build_cache_dir}"
      ],
     "benchmark_dir": "benchmarks",
-    "environment_type": "virtualenv",
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",
-    "html_dir": ".asv/html",
+    "environment_type": "virtualenv",
     "build_cache_size": 2,
 }

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -5,6 +5,7 @@
     "repo": ".",
     "build_command": [
           "python -m pip install build",
+          "/usr/bin/cp -r {build_dir}/cpp {build_dir}/python/cpp",
           "in-dir={build_dir}/python python -m build",
           "/usr/bin/cp -r {build_dir}/python/dist/. {build_cache_dir}"
      ],

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -3,11 +3,10 @@
     "project": "voyager",
     "project_url": "https://spotify.github.io/voyager/",
     "repo": ".",
-    "repo_subdir": "python",
     "build_command": [
           "python -m pip install build",
-          "python -m build",
-          "/usr/bin/cp -r {build_dir}/dist/. {build_cache_dir}"
+          "in-dir={build_dir}/python python -m build",
+          "/usr/bin/cp -r {build_dir}/python/dist/. {build_cache_dir}"
      ],
     "benchmark_dir": "benchmarks",
     "environment_type": "virtualenv",

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -5,8 +5,11 @@
     "repo": ".",
     "build_command": [
           "python -m pip install build",
-          "pip install -r {build_dir}/python/dev-requirements.txt",
-          "in-dir={build_dir}/python python -m build --no-isolation",
+          "/usr/bin/cp -r {build_dir}/cpp {build_dir}/python/cpp",
+          "/usr/bin/cp {build_dir}/README.md {build_dir}/python/README.md",
+          "/usr/bin/sed -i '$ a\graft cpp' {build_dir}/python/MANIFEST.in",
+          "/usr/bin/sed -i '$ a\include voyager/version.py' {build_dir}/python/MANIFEST.in",
+          "in-dir={build_dir}/python python -m build",
           "/usr/bin/cp -r {build_dir}/python/dist/. {build_cache_dir}"
      ],
     "benchmark_dir": "benchmarks",

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,18 @@
+{
+    "version": 1,
+    "project": "voyager",
+    "project_url": "https://spotify.github.io/voyager/",
+    "repo": ".",
+    "repo_subdir": "python",
+    "build_command": [
+          "python -m pip install build",
+          "python -m build",
+          "/usr/bin/cp -r {build_dir}/dist/. {build_cache_dir}"
+     ],
+    "benchmark_dir": "benchmarks",
+    "environment_type": "virtualenv",
+    "env_dir": ".asv/env",
+    "results_dir": ".asv/results",
+    "html_dir": ".asv/html",
+    "build_cache_size": 2,
+}

--- a/benchmarks/index_creation.py
+++ b/benchmarks/index_creation.py
@@ -30,7 +30,7 @@ class IndexCreationSuite:
     param_names = ['num_dimensions','num_elements', 'space', 'storage_data_type', 'ef_construction']
 
 
-    def create(
+    def time_create(
         self,
         num_dimensions: int,
         num_elements: int,

--- a/benchmarks/index_creation.py
+++ b/benchmarks/index_creation.py
@@ -20,23 +20,23 @@ import voyager
 
 class IndexCreationSuite:
 
+    repeat = (1, 10, 30.0)
     params = (
         [256],
-        [1024], 
+        [1024],
         [voyager.Space.Euclidean, voyager.Space.Cosine],
-        [voyager.StorageDataType.E4M3,voyager.StorageDataType.Float8,voyager.StorageDataType.Float32],
-        [24]
-        )
-    param_names = ['num_dimensions','num_elements', 'space', 'storage_data_type', 'ef_construction']
+        [voyager.StorageDataType.E4M3, voyager.StorageDataType.Float8, voyager.StorageDataType.Float32],
+        [24],
+    )
+    param_names = ["num_dimensions", "num_elements", "space", "storage_data_type", "ef_construction"]
 
-
-    def time_create(
+    def setup(
         self,
         num_dimensions: int,
         num_elements: int,
         space: voyager.Space,
         storage_data_type: voyager.StorageDataType,
-        ef_construction: float
+        ef_construction: float,
     ):
         generator = np.random.default_rng(seed=1234)
         input_data = generator.random((num_elements, num_dimensions)).astype(np.float32) * 2 - 1
@@ -52,6 +52,8 @@ class IndexCreationSuite:
             storage_data_type=storage_data_type,
         )
 
-        index.add_items(input_data)
+        self.input_data = input_data
+        self.index = index
 
-
+    def time_create(self, *_):
+        self.index.add_items(self.input_data, num_threads=1)

--- a/benchmarks/index_creation.py
+++ b/benchmarks/index_creation.py
@@ -1,0 +1,57 @@
+#
+# Copyright 2022-2023 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import voyager
+
+
+class IndexCreationSuite:
+
+    params = (
+        [256],
+        [1024], 
+        [voyager.Space.Euclidean, voyager.Space.Cosine],
+        [voyager.StorageDataType.E4M3,voyager.StorageDataType.Float8,voyager.StorageDataType.Float32],
+        [24]
+        )
+    param_names = ['num_dimensions','num_elements', 'space', 'storage_data_type', 'ef_construction']
+
+
+    def create(
+        self,
+        num_dimensions: int,
+        num_elements: int,
+        space: voyager.Space,
+        storage_data_type: voyager.StorageDataType,
+        ef_construction: float
+    ):
+        generator = np.random.default_rng(seed=1234)
+        input_data = generator.random((num_elements, num_dimensions)).astype(np.float32) * 2 - 1
+
+        if storage_data_type == voyager.StorageDataType.Float8:
+            input_data = np.round(input_data * 127) / 127
+
+        index = voyager.Index(
+            space=space,
+            num_dimensions=num_dimensions,
+            ef_construction=ef_construction,
+            M=20,
+            storage_data_type=storage_data_type,
+        )
+
+        index.add_items(input_data)
+
+

--- a/benchmarks/index_query.py
+++ b/benchmarks/index_query.py
@@ -1,0 +1,88 @@
+#
+# Copyright 2022-2023 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from io import BytesIO
+from itertools import product
+from typing import Dict
+
+import numpy as np
+
+import voyager
+
+
+class IndexQuerySuite:
+
+    repeat = (1, 10, 30.0)
+    params = (
+        [256],
+        [1024],
+        [voyager.Space.Euclidean, voyager.Space.Cosine],
+        [voyager.StorageDataType.E4M3, voyager.StorageDataType.Float8, voyager.StorageDataType.Float32],
+        [24],
+    )
+    param_names = ["num_dimensions", "num_elements", "space", "storage_data_type", "ef_construction"]
+
+    def setup_cache(self) -> Dict:
+
+        param_combinations = product(*self.params)
+
+        data = {}
+        for param_combination in param_combinations:
+            num_dimensions, num_elements, space, storage_data_type, ef_construction = param_combination
+
+            generator = np.random.default_rng(seed=1234)
+            input_data = generator.random((num_elements, num_dimensions)).astype(np.float32) * 2 - 1
+
+            if storage_data_type == voyager.StorageDataType.Float8:
+                input_data = np.round(input_data * 127) / 127
+
+            index = voyager.Index(
+                space=space,
+                num_dimensions=num_dimensions,
+                ef_construction=ef_construction,
+                M=20,
+                storage_data_type=storage_data_type,
+            )
+            index.add_items(input_data)
+
+            data[param_combination] = (index.as_bytes(), input_data)
+
+        return data
+
+    def setup(
+        self,
+        cached_data: Dict,
+        num_dimensions: int,
+        num_elements: int,
+        space: voyager.Space,
+        storage_data_type: voyager.StorageDataType,
+        ef_construction: float,
+    ):
+        index_as_bytes, self.input_data = cached_data[
+            num_dimensions, num_elements, space, storage_data_type, ef_construction
+        ]
+        self.index = voyager.Index.load(BytesIO(index_as_bytes))
+
+    def time_query_k_1(self, *_):
+        self.index.query(self.input_data, k=1, num_threads=1)
+
+    def time_query_k_20(self, *_):
+        self.index.query(self.input_data, k=20, num_threads=1)
+
+    def track_recall(self, *_):
+        labels, _ = self.index.query(self.input_data, k=1, num_threads=1)
+        matches = np.sum(labels[:, 0] == np.arange(len(self.input_data)))
+        recall = matches / len(self.input_data)
+        return recall

--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -5,6 +5,7 @@ pybind11-stubgen==0.16.2
 ruff
 psutil
 mypy
+asv==0.6.3
 # Needed for sphinx documentation
 sphinx
 sphinxext-opengraph

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ else:
     raise OSError(
         "Unable to find the 'cpp' folder to build voyager. "
         f"Current working directory is: {os.getcwd()}, directory contains: "
-        f"{', '.join([repr(x) for x in dir_contents])} and {len(dir_contents) - 5} more files."
+        f"{', '.join([repr(x) for x in dir_contents[:5]])} and {len(dir_contents) - 5} more files."
     )
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ else:
     raise OSError(
         "Unable to find the 'cpp' folder to build voyager. "
         f"Current working directory is: {os.getcwd()}, directory contains: "
-        f"{', '.join([repr(x) for x in dir_contents[:5]])} and {len(dir_contents) - 5} more files."
+        f"{', '.join([repr(x) for x in dir_contents])} and {len(dir_contents) - 5} more files."
     )
 
 


### PR DESCRIPTION
## Description

In this PR we will:
- Add the skaffolding to use [airspeed-velocity](https://asv.readthedocs.io/en/v0.6.1/) as the benchmarking framework for voyager
- Have benchmakrs being run in CI, with output shown as a build step summary (example [here](https://github.com/spotify/voyager/actions/runs/10109994701/attempts/1#summary-27959007587))
- Add three parametrized benchmarks: index creation runtime, index query runtime, index query recall
## Changes Made

- Added `benchmarks` folder in the root of the project
- Added airspeed velocity config file
- Added build step to run benchmarks and print output as a build step summary

## Testing
<!-- Outline the testing strategy employed to validate these changes. Include any relevant test cases or scenarios. -->

## Checklist
<!-- 
    Replace [ ] with [x] to check off items. 
    For items that are not applicable, simply remove the checkbox.
-->

- [x] My code follows the code style of this project.
- [x] I have added and/or updated appropriate documentation (if applicable).
- [x] All new and existing tests pass locally with these changes.
- [x] I have run static code analysis (if available) and resolved any issues.
- [x] I have considered backward compatibility (if applicable).
- [x] I have confirmed that this PR does not introduce any security vulnerabilities.

## Additional Comments
<!-- Add any additional comments or notes that might be helpful for reviewers or contributors. -->
