### PR TITLE
Disable CI tests on `aarch64`

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -274,7 +274,7 @@ jobs:
           CIBW_ENVIRONMENT: NPY_BLAS_ORDER="" NPY_LAPACK_ORDER=""
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: pip install auditwheel-symbols && (auditwheel repair -w {dest_dir} {wheel} || auditwheel-symbols --manylinux 2010 {wheel})
           # Use the minimum macOS deployment target that has C++17 support:
-          CIBW_TEST_SKIP: "*aarch64*"
+          CIBW_TEST_SKIP: "*aarch64"
           MACOSX_DEPLOYMENT_TARGET: "10.13"
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -274,6 +274,7 @@ jobs:
           CIBW_ENVIRONMENT: NPY_BLAS_ORDER="" NPY_LAPACK_ORDER=""
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: pip install auditwheel-symbols && (auditwheel repair -w {dest_dir} {wheel} || auditwheel-symbols --manylinux 2010 {wheel})
           # Use the minimum macOS deployment target that has C++17 support:
+          CIBW_TEST_SKIP: "*aarch64*"
           MACOSX_DEPLOYMENT_TARGET: "10.13"
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
## Description

In this PR we will:
- Disable tests on `aarch64` wheels in github actions, since they run via emulation and are quite slow

## Changes Made

- Added `CIBW_SKIP_TEST` env var to the build wheels run step

## Testing
<!-- Outline the testing strategy employed to validate these changes. Include any relevant test cases or scenarios. -->

## Checklist
<!-- 
    Replace [ ] with [x] to check off items. 
    For items that are not applicable, simply remove the checkbox.
-->

- [x] My code follows the code style of this project.
- [x] I have added and/or updated appropriate documentation (if applicable).
- [x] All new and existing tests pass locally with these changes.
- [x] I have run static code analysis (if available) and resolved any issues.
- [x] I have considered backward compatibility (if applicable).
- [x] I have confirmed that this PR does not introduce any security vulnerabilities.

## Additional Comments
<!-- Add any additional comments or notes that might be helpful for reviewers or contributors. -->
