### PR TITLE
Fix for flaky GLIBC check on CI build

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -379,13 +379,13 @@ jobs:
           echo "Checking the Linux JARs to ensure a sufficiently old required GLIBC and GLIBCXX version in each..."
 
           echo "Checking linux-aarch64/libvoyager.so (should require at most GLIBC 2.27...)"
-          objdump -T combined-jar/linux-aarch64/libvoyager.so | grep GLIBC | grep -v GLIBCXX | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 2\.27 || (echo "Expected linux-aarch64 binary to require at most glibc 2.27. Ensure the dockcross container has not been updated." && false)
+          objdump -T combined-jar/linux-aarch64/libvoyager.so | grep GLIBC | grep -v GLIBCXX | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | cat - <(echo 2\.27) | sort -Vu | tail -n 1 | grep 2\.27 || (echo "Expected linux-aarch64 binary to require at most glibc 2.27. Ensure the dockcross container has not been updated." && false)
           echo "Checking linux-aarch64/libvoyager.so (should require at most GLIBCXX 3.4.22...)"
-          objdump -T combined-jar/linux-aarch64/libvoyager.so | grep GLIBCXX | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 3\.4\.22 || (echo "Expected linux-aarch64 binary to require at most glibc++ 3.4.22. Ensure the dockcross container has not been updated." && false)
+          objdump -T combined-jar/linux-aarch64/libvoyager.so | grep GLIBCXX | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | cat - <(echo 3\.4\.22) | sort -Vu | tail -n 1 | grep 3\.4\.22 || (echo "Expected linux-aarch64 binary to require at most glibc++ 3.4.22. Ensure the dockcross container has not been updated." && false)
           echo "Checking linux-x64/libvoyager.so (should require at most GLIBC 2.27...)"
-          objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBC | grep -v GLIBCXX | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 2\.27 || (echo "Expected linux-x64 binary to require at most glibc 2.28. Ensure the dockcross container has not been updated." && false)
+          objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBC | grep -v GLIBCXX | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | cat - <(echo 2\.27) | sort -Vu | tail -n 1 | grep 2\.27 || (echo "Expected linux-x64 binary to require at most glibc 2.28. Ensure the dockcross container has not been updated." && false)
           echo "Checking linux-x64/libvoyager.so (should require at most GLIBCXX 3.4.22...)"
-          objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBCXX | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 3\.4\.22  || (echo "Expected linux-x64 binary to require at most glibc++ 3.4.22. Ensure the dockcross container has not been updated." && false)
+          objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBCXX | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | cat - <(echo 3\.4\.22) | sort -Vu | tail -n 1 | grep 3\.4\.22  || (echo "Expected linux-x64 binary to require at most glibc++ 3.4.22. Ensure the dockcross container has not been updated." && false)
 
           zip -r $(ls java-* | grep jar | tail -n 1) combined-jar/*
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -379,11 +379,11 @@ jobs:
           echo "Checking the Linux JARs to ensure a sufficiently old required GLIBC and GLIBCXX version in each..."
 
           echo "Checking linux-aarch64/libvoyager.so (should require at most GLIBC 2.27...)"
-          objdump -T combined-jar/linux-aarch64/libvoyager.so | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 2\.27 || (echo "Expected linux-aarch64 binary to require at most glibc 2.27. Ensure the dockcross container has not been updated." && false)
+          objdump -T combined-jar/linux-aarch64/libvoyager.so | grep GLIBC | grep -v GLIBCXX | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 2\.27 || (echo "Expected linux-aarch64 binary to require at most glibc 2.27. Ensure the dockcross container has not been updated." && false)
           echo "Checking linux-aarch64/libvoyager.so (should require at most GLIBCXX 3.4.22...)"
           objdump -T combined-jar/linux-aarch64/libvoyager.so | grep GLIBCXX | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 3\.4\.22 || (echo "Expected linux-aarch64 binary to require at most glibc++ 3.4.22. Ensure the dockcross container has not been updated." && false)
           echo "Checking linux-x64/libvoyager.so (should require at most GLIBC 2.27...)"
-          objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 2\.27 || (echo "Expected linux-x64 binary to require at most glibc 2.28. Ensure the dockcross container has not been updated." && false)
+          objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBC | grep -v GLIBCXX | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 2\.27 || (echo "Expected linux-x64 binary to require at most glibc 2.28. Ensure the dockcross container has not been updated." && false)
           echo "Checking linux-x64/libvoyager.so (should require at most GLIBCXX 3.4.22...)"
           objdump -T combined-jar/linux-x64/libvoyager.so | grep GLIBCXX | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | sort -Vu | tail -n 1 | grep 3\.4\.22  || (echo "Expected linux-x64 binary to require at most glibc++ 3.4.22. Ensure the dockcross container has not been updated." && false)
 


### PR DESCRIPTION
## Description
In the `Combine JAR` step of the CI build we check for shared libraries to require `GLIBC<=2.27`. We do that by dumping objects from shared libraries, grepping for `GLIBC`, removing unrelated string parts and sorting. But in this way we are catching also `GLIBCXX` entries, so ultimately the check depends on whether last matched object in the library is a `GLIBC` or  `GLIBCXX` entry.


Also the test currently is failing if the maximum GLIBC/GLIBCXX required version by the library is strickly less than the maximum we allow.

## Changes Made

- Improve check in the `Combine JAR` CI step.

## Testing
<!-- Outline the testing strategy employed to validate these changes. Include any relevant test cases or scenarios. -->

## Checklist
<!-- 
    Replace [ ] with [x] to check off items. 
    For items that are not applicable, simply remove the checkbox.
-->

- [x] My code follows the code style of this project.
- [x] I have added and/or updated appropriate documentation (if applicable).
- [x] All new and existing tests pass locally with these changes.
- [x] I have run static code analysis (if available) and resolved any issues.
- [x] I have considered backward compatibility (if applicable).
- [x] I have confirmed that this PR does not introduce any security vulnerabilities.

## Additional Comments
<!-- Add any additional comments or notes that might be helpful for reviewers or contributors. -->
