### PR TITLE
Fix CI failures on windows and macos

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -61,8 +61,7 @@ jobs:
           submodules: recursive
       - name: Install CMake (Windows)
         if: matrix.os == 'windows-latest'
-        run: |
-          choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
+        run: cmake --version
       - name: Install CMake (MacOS)
         if: matrix.os == 'macos-12'
         run: brew install cmake

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -49,11 +49,10 @@ jobs:
         working-directory: cpp
     strategy:
       matrix:
-        # TODO: Switch back to macos-latest once https://github.com/actions/python-versions/pull/114 is fixed
         os:
           - 'ubuntu-latest'
           - windows-latest
-          - macos-12
+          - macos-latest
     name: Test C++ on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -63,7 +62,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cmake --version
       - name: Install CMake (MacOS)
-        if: matrix.os == 'macos-12'
+        if: matrix.os == 'macos-latest'
         run: brew install cmake
       - name: Install CMake (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -80,7 +79,7 @@ jobs:
         working-directory: java
     strategy:
       matrix:
-        os: ['ubuntu-latest', windows-latest, macos-12]
+        os: ['ubuntu-latest', windows-latest, macos-latest]
         java-version: ['11', '17']
     steps:
       - uses: actions/checkout@v3
@@ -143,8 +142,7 @@ jobs:
 #           - '3.9'
 #           - '3.10'
 #           - '3.11'
-        # TODO: Switch back to macos-latest once https://github.com/actions/python-versions/pull/114 is fixed
-        os: ['ubuntu-latest', windows-latest, macos-12]
+        os: ['ubuntu-latest', windows-latest, macos-latest]
     name: Test with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -255,25 +253,25 @@ jobs:
     strategy:
       matrix:
         include:
-        - { os: macos-12, build: cp37-macosx_x86_64 }
-        - { os: macos-12, build: cp38-macosx_x86_64 }
-        - { os: macos-12, build: cp39-macosx_x86_64 }
-        - { os: macos-12, build: cp310-macosx_x86_64 }
-        - { os: macos-12, build: cp311-macosx_x86_64 }
-        - { os: macos-12, build: cp312-macosx_x86_64 }
-        - { os: macos-12, build: cp38-macosx_universal2 }
-        - { os: macos-12, build: cp39-macosx_universal2 }
-        - { os: macos-12, build: cp310-macosx_universal2 }
-        - { os: macos-12, build: cp311-macosx_universal2 }
-        - { os: macos-12, build: cp312-macosx_universal2 }
-        - { os: macos-12, build: cp38-macosx_arm64 }
-        - { os: macos-12, build: cp39-macosx_arm64 }
-        - { os: macos-12, build: cp310-macosx_arm64 }
-        - { os: macos-12, build: cp311-macosx_arm64 }
-        - { os: macos-12, build: cp312-macosx_arm64 }
-        # - { os: macos-12, build: pp37-macosx_x86_64 }
-        # - { os: macos-12, build: pp38-macosx_x86_64 }
-        # - { os: macos-12, build: pp39-macosx_x86_64 }
+        - { os: macos-latest, build: cp37-macosx_x86_64 }
+        - { os: macos-latest, build: cp38-macosx_x86_64 }
+        - { os: macos-latest, build: cp39-macosx_x86_64 }
+        - { os: macos-latest, build: cp310-macosx_x86_64 }
+        - { os: macos-latest, build: cp311-macosx_x86_64 }
+        - { os: macos-latest, build: cp312-macosx_x86_64 }
+        - { os: macos-latest, build: cp38-macosx_universal2 }
+        - { os: macos-latest, build: cp39-macosx_universal2 }
+        - { os: macos-latest, build: cp310-macosx_universal2 }
+        - { os: macos-latest, build: cp311-macosx_universal2 }
+        - { os: macos-latest, build: cp312-macosx_universal2 }
+        - { os: macos-latest, build: cp38-macosx_arm64 }
+        - { os: macos-latest, build: cp39-macosx_arm64 }
+        - { os: macos-latest, build: cp310-macosx_arm64 }
+        - { os: macos-latest, build: cp311-macosx_arm64 }
+        - { os: macos-latest, build: cp312-macosx_arm64 }
+        # - { os: macos-latest, build: pp37-macosx_x86_64 }
+        # - { os: macos-latest, build: pp38-macosx_x86_64 }
+        # - { os: macos-latest, build: pp39-macosx_x86_64 }
         - { os: windows-latest, build: cp37-win_amd64 }
         - { os: windows-latest, build: cp38-win_amd64 }
         - { os: windows-latest, build: cp39-win_amd64 }
@@ -350,7 +348,7 @@ jobs:
         working-directory: java
     strategy:
       matrix:
-        os: ['ubuntu-latest', windows-latest, macos-12]
+        os: ['ubuntu-latest', windows-latest, macos-latest]
         java-version: ['11']
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description
- Looks like there's something wrong with cmake installation on the windows github action image ([here](https://github.com/actions/runner-images/issues/11174)). Cmake is already installed anyway, so we don't need it install it explicitly
- Bumped macos image from version 12 to latest, since macos-12 has been removed