### PR TITLE
Fix benchmarks failing in github CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cpp/include/doctest"]
 	path = cpp/include/doctest
-	url = git@github.com:doctest/doctest.git
+	url = https://github.com/doctest/doctest.git


### PR DESCRIPTION
## Description
Currently benchmarks are failing when ran in github CI because we are checking out the `doctest` git submodule via ssh, without having a valid ssh key.

## Changes Made
Since `doctest` it's a public repo, we can just use the https checkout, which does not require any authentication
