### PR TITLE
more descriptive error message when there is a dimension mismatch

### DIFF
--- a/cpp/src/TypedIndex.h
+++ b/cpp/src/TypedIndex.h
@@ -531,7 +531,10 @@ public:
 
     if (numFeatures != dimensions) {
       throw std::runtime_error(
-          "Query vectors expected to share dimensionality with index.");
+          "Query vectors expected to share dimensionality with index. Index "
+          "dims: " +
+          std::to_string(dimensions) +
+          ", query vector dims: " + std::to_string(numFeatures));
     }
 
     NDArray<hnswlib::labeltype, 2> labels({numRows, k});


### PR DESCRIPTION
## Description
<!-- Describe the changes introduced by this pull request and why they are necessary. -->
More descriptive error message when there is a dimension mismatch between the query vector(s) and the index vectors. 

