### PR TITLE
Fix benchmarks failing and adjust compilation flags

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -11,7 +11,10 @@
           "/usr/bin/sed -i '$ a\include voyager/version.py' {build_dir}/python/MANIFEST.in",
           "in-dir={build_dir}/python python -m build",
           "/usr/bin/cp -r {build_dir}/python/dist/. {build_cache_dir}"
-     ],
+    ],
+    "install_command": [
+          "in-dir={env_dir} python -mpip install {wheel_file} numpy"
+    ],
     "benchmark_dir": "benchmarks",
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",

--- a/java/Makefile
+++ b/java/Makefile
@@ -17,13 +17,13 @@ ifeq ($(UNAME_S),Linux)
 CXX       := g++
 JAVA_INC  := $(JAVA_HOME)/include $(JAVA_HOME)/include/linux
 ALL_OBJS  := target/classes/linux-x64/$(LINUX_SOBJ) target/classes/linux-aarch64/$(LINUX_SOBJ)
-CXXFLAGS  := -I. -lc -shared -std=c++17 -I ./include $(addprefix -I,$(JAVA_INC)) -I $(CPP_SRC_DIR) -fPIC -O3
+CXXFLAGS  := -I. -lc -shared -std=c++17 -I ./include $(addprefix -I,$(JAVA_INC)) -I $(CPP_SRC_DIR) -fPIC -O3 -fassociative-math -fno-signaling-nans -fno-trapping-math -fno-signed-zeros -freciprocal-math -fno-math-errno
 PREBUILD_COMMAND := sudo apt-get update && sudo apt-get install -y ca-certificates-java openjdk-11-jre-headless; { curl https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz | sudo tar -xvzf - -C /opt ; }; export M2_HOME=/opt/apache-maven-3.9.2 && export PATH=\"${M2_HOME}/bin:${PATH}\"
 else ifeq ($(UNAME_S),Darwin)
 CXX       := clang++
 JAVA_INC  := $(JAVA_HOME)/include $(JAVA_HOME)/include/darwin
 ALL_OBJS  := target/classes/mac-x64/$(MAC_SOBJ) target/classes/mac-aarch64/$(MAC_SOBJ)
-CXXFLAGS  := -I. -lc++ -shared -std=c++17 -I ./include $(addprefix -I,$(JAVA_INC)) -I $(CPP_SRC_DIR) -fPIC -O3
+CXXFLAGS  := -I. -lc++ -shared -std=c++17 -I ./include $(addprefix -I,$(JAVA_INC)) -I $(CPP_SRC_DIR) -fPIC -O3 -fassociative-math -fno-signaling-nans -fno-trapping-math -fno-signed-zeros -freciprocal-math -fno-math-errno
 else ifdef OS # Windows:
 CXX       := cl.exe
 JAVA_INC  := $(JAVA_HOME)/include $(JAVA_HOME)/include/win32

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -57,7 +57,7 @@ if (IS_UNIX)
   add_compile_options(-fassociative-math -fno-signaling-nans -fno-trapping-math -fno-signed-zeros -freciprocal-math -fno-math-errno)
 endif()
 
-# Relase build on unix with all optimizations
+# Relase build with all optimizations
 if (CMAKE_BUILD_TYPE STREQUAL "Release" AND IS_UNIX)
   add_compile_options(-O3)
 elseif (CMAKE_BUILD_TYPE STREQUAL "Release" AND IS_WINDOWS)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -31,6 +31,8 @@ else()
   set(DEV_MODULE Development.Module)
 endif()
 
+set(IS_UNIX ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+
 find_package(Python 3.8 COMPONENTS Interpreter ${DEV_MODULE})
 
 # Import nanobind through CMake's find_package mechanism
@@ -48,18 +50,31 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
 find_package(nanobind CONFIG REQUIRED)
 
+# Allow for some math optimization on unix but not -ffast-math
+# See: https://simonbyrne.github.io/notes/fastmath/#flushing_subnormals_to_zero
+if (IS_UNIX)
+  add_compile_options(-fassociative-math -fno-signaling-nans -fno-trapping-math -fno-signed-zeros -freciprocal-math -fno-math-errno)
+endif()
+
+# Relase build on unix with all optimizations
+if (CMAKE_BUILD_TYPE STREQUAL "Release" AND IS_UNIX)
+  add_compile_options(-O3)
+endif()
+
+
 # Check the USE_ASAN environment variable, and if set to 1, enable AddressSanitizer
 if (DEFINED ENV{USE_ASAN} AND "$ENV{USE_ASAN}" STREQUAL "1")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+  add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=address)
 endif()
+
 
 nanobind_add_module(
   voyager_ext
   # Target the stable ABI for Python 3.12+, which reduces
   # the number of binary wheels that must be built. This
   # does nothing on older Python versions
-  NB_STATIC STABLE_ABI LTO FREE_THREADED
+  NB_STATIC STABLE_ABI LTO FREE_THREADED NOMINSIZE
   # Sources:
   src/bindings.cpp
 )

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -32,6 +32,7 @@ else()
 endif()
 
 set(IS_UNIX ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+set(IS_WINDOWS ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 
 find_package(Python 3.8 COMPONENTS Interpreter ${DEV_MODULE})
 
@@ -59,6 +60,8 @@ endif()
 # Relase build on unix with all optimizations
 if (CMAKE_BUILD_TYPE STREQUAL "Release" AND IS_UNIX)
   add_compile_options(-O3)
+elseif (CMAKE_BUILD_TYPE STREQUAL "Release" AND IS_WINDOWS)
+  add_compile_options(/Ox)
 endif()
 
 


### PR DESCRIPTION
## Description

Three contributions in this PR:

- Now that we have moved to nanobind and do not depend to numpy anymore, we need to install numpy when running the benchmarks.
- when building python package compile native code using `-O3` and some math optimization
- Enable same math optimization in the native code build for the java package