### PR TITLE
Fix for release to PyPi build step bug

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: java
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'


### PR DESCRIPTION
## Description
After #113 we need to download all artifacts that are now named like `python-wheels-${{ matrix.build }}`
