### PR TITLE
Fix: Correct clang-format column limit to 120

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -5,4 +5,4 @@ InsertNewlineAtEOF: true
 ---
 Language: Cpp
 # Use 120 columns since we have big screens now
-ColumnLimit: 80
+ColumnLimit: 120


### PR DESCRIPTION
The .clang-format configuration incorrectly specified a column limit of 80, despite comments and the related commit's intention to set it to 120.

This change updates the `ColumnLimit` parameter to the correct value, ensuring that the code formatter aligns with the project's established style guide.