### PR TITLE
docs: update Voyager dependency versions to 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the following artifact to your `pom.xml`:
 <dependency>
   <groupId>com.spotify</groupId>
   <artifactId>voyager</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
 </dependency>
 ```
 You can find the latest version on [Voyager's Releases page](https://github.com/spotify/voyager/releases).
@@ -43,7 +43,7 @@ You can find the latest version on [Voyager's Releases page](https://github.com/
 
 Add the following artifact to your `build.sbt`:
 ```sbt
-"com.spotify" % "voyager" % "2.1.0"
+"com.spotify" % "voyager" % "2.1.1"
 ```
 You can find the latest version on [Voyager's Releases page](https://github.com/spotify/voyager/releases).
 


### PR DESCRIPTION
## Description
<!-- Describe the changes introduced by this pull request and why they are necessary. -->
The README previously listed version 2.1.0 for Maven and SBT dependencies. The latest release of Voyager is 2.1.1.

This PR updates the dependency versions in the installation instructions for Java (Maven) and Scala (SBT) to match the latest release, ensuring that users installing Voyager will get the most up-to-date version with all recent fixes and improvements.

No code changes were made—this update is purely for documentation accuracy.


## Related Issues
<!-- Reference any related GitHub issues that are addressed by this pull request. -->
_None_

## Changes Made
<!-- Provide a brief overview of the changes made in this pull request. -->
 - Updated Maven dependency version from `2.1.0` → `2.1.1`
 - Updated Scala SBT dependency version from `2.1.0` → `2.1.1`


## Testing
<!-- Outline the testing strategy employed to validate these changes. Include any relevant test cases or scenarios. -->
_Not applicable_


## Checklist
<!-- 
    Replace [ ] with [x] to check off items. 
    For items that are not applicable, simply remove the checkbox.
-->

- [ ] My code follows the code style of this project.
- [x] I have added and/or updated appropriate documentation (if applicable).
- [ ] All new and existing tests pass locally with these changes.
- [ ] I have run static code analysis (if available) and resolved any issues.
- [ ] I have considered backward compatibility (if applicable).
- [ ] I have confirmed that this PR does not introduce any security vulnerabilities.


## Additional Comments
<!-- Add any additional comments or notes that might be helpful for reviewers or contributors. -->
This PR is purely a documentation update to ensure the README matches the latest release.
