### PR TITLE
Drop Python 3.7 and 3.8 support, require 3.9+

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -137,7 +137,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
+          - '3.9'
           - '3.13'
         os: ['ubuntu-latest', windows-latest, macos-latest]
     name: Test with Python ${{ matrix.python-version }} on ${{ matrix.os }}
@@ -177,7 +177,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
+          - '3.9'
         os: ['ubuntu-latest']
     name: Test with Python ${{ matrix.python-version }} + Address Sanitizer
     steps:
@@ -281,32 +281,26 @@ jobs:
     strategy:
       matrix:
         include:
-        - { os: macos-latest, build: cp38-macosx_x86_64 }
         - { os: macos-latest, build: cp39-macosx_x86_64 }
         - { os: macos-latest, build: cp310-macosx_x86_64 }
         - { os: macos-latest, build: cp311-macosx_x86_64 }
         - { os: macos-latest, build: cp312-macosx_x86_64 }
         - { os: macos-latest, build: cp313-macosx_x86_64 }
-        - { os: macos-latest, build: cp38-macosx_universal2 }
         - { os: macos-latest, build: cp39-macosx_universal2 }
         - { os: macos-latest, build: cp310-macosx_universal2 }
         - { os: macos-latest, build: cp311-macosx_universal2 }
         - { os: macos-latest, build: cp312-macosx_universal2 }
         - { os: macos-latest, build: cp313-macosx_universal2 }
-        - { os: macos-latest, build: cp38-macosx_arm64 }
         - { os: macos-latest, build: cp39-macosx_arm64 }
         - { os: macos-latest, build: cp310-macosx_arm64 }
         - { os: macos-latest, build: cp311-macosx_arm64 }
         - { os: macos-latest, build: cp312-macosx_arm64 }
         - { os: macos-latest, build: cp313-macosx_arm64 }
-        - { os: windows-latest, build: cp38-win_amd64 }
         - { os: windows-latest, build: cp39-win_amd64 }
         - { os: windows-latest, build: cp310-win_amd64 }
         - { os: windows-latest, build: cp311-win_amd64 }
         - { os: windows-latest, build: cp312-win_amd64 }
         - { os: windows-latest, build: cp313-win_amd64 }
-        - { os: 'ubuntu-latest', build: cp38-manylinux_x86_64 }
-        - { os: 'ubuntu-latest', build: cp38-manylinux_aarch64 }
         - { os: 'ubuntu-latest', build: cp39-manylinux_x86_64 }
         - { os: 'ubuntu-latest', build: cp39-manylinux_aarch64 }
         - { os: 'ubuntu-latest', build: cp310-manylinux_x86_64 }

--- a/README.md
+++ b/README.md
@@ -52,24 +52,18 @@ You can find the latest version on [Voyager's Releases page](https://github.com/
 
 | OS        | Language | Version | x86_64 (Intel) | arm64 (ARM) |
 |-----------|----------|---------|---------| --------|
-| Linux     | Python   | 3.7     | ✅       | ✅       |
-| Linux     | Python   | 3.8     | ✅       | ✅       |
 | Linux     | Python   | 3.9     | ✅       | ✅       |
 | Linux     | Python   | 3.10    | ✅       | ✅       |
 | Linux     | Python   | 3.11    | ✅       | ✅       |
 | Linux     | Python   | 3.12    | ✅       | ✅       |
 | Linux     | Python   | 3.13    | ✅       | ✅       |
 | Linux     | Java     | 8-16+   | ✅       | ✅      |
-| macOS     | Python   | 3.7     | ✅       | ✅       |
-| macOS     | Python   | 3.8     | ✅       | ✅       |
 | macOS     | Python   | 3.9     | ✅       | ✅       |
 | macOS     | Python   | 3.10    | ✅       | ✅       |
 | macOS     | Python   | 3.11    | ✅       | ✅       |
 | macOS     | Python   | 3.12    | ✅       | ✅       |
 | macOS     | Python   | 3.13    | ✅       | ✅       |
 | macOS     | Java     | 8-16+   | ✅       | ✅       |
-| Windows   | Python   | 3.7     | ✅       | ❌       |
-| Windows   | Python   | 3.8     | ✅       | ❌       |
 | Windows   | Python   | 3.9     | ✅       | ❌       |
 | Windows   | Python   | 3.10    | ✅       | ❌       |
 | Windows   | Python   | 3.11    | ✅       | ❌       |

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 set(IS_UNIX ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 set(IS_WINDOWS ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 
-find_package(Python 3.8 COMPONENTS Interpreter ${DEV_MODULE})
+find_package(Python 3.9 COMPONENTS Interpreter ${DEV_MODULE})
 
 # Import nanobind through CMake's find_package mechanism
 find_package(nanobind CONFIG REQUIRED)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "voyager"
 version = "2.0.10"
 description = "Easy-to-use, fast, simple multi-platform approximate nearest-neighbor search library."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Peter Sobot", email = "psobot@spotify.com" },
 ]
@@ -20,8 +20,6 @@ classifiers = [
          "Programming Language :: C++",
          "Programming Language :: Python",
          "Topic :: Database :: Database Engines/Servers",
-         "Programming Language :: Python :: 3.7",
-         "Programming Language :: Python :: 3.8",
          "Programming Language :: Python :: 3.9",
          "Programming Language :: Python :: 3.10",
          "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
**Python 3.8 reached end-of-life in October 2024 so we are dropping support for it.**

## Summary
- nanobind requires Python 3.9 as a minimum version, so Python 3.7 and 3.8 are no longer supported
- Bumped `requires-python` to `>=3.9` and removed 3.7/3.8 PyPI classifiers in `pyproject.toml`
- Updated CMake `find_package(Python ...)` minimum from 3.8 to 3.9
- Removed all 6 `cp38` wheel builds from CI (macOS x86_64/universal2/arm64, Windows amd64, Linux x86_64/aarch64)
- Updated CI test matrices to use Python 3.9 as the lower bound (both standard and ASan tests)
- Removed Python 3.7 and 3.8 rows from README compatibility table